### PR TITLE
Updated serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -40,4 +40,4 @@ functions:
     environment:
       FAILURE_SNS: ${cf:stripe-eventbridge-deps-${self:provider.stage}.SNSTargetForFailedEvents}
       EVENT_BRIDGE: "default"
-      ENDPOINT_SECRET: "${cf:stripe-eventbridge-deps-${self:provider.stage}.StripeWebhookSecretArn.Name}"
+      ENDPOINT_SECRET: "${cf:stripe-eventbridge-deps-${self:provider.stage}.StripeWebhookSecretArn}"


### PR DESCRIPTION
Current code in main directory causes the following error: 

 Trying to request a non exported variable from CloudFormation. Stack name: "stripe-eventbridge-deps-dev" Requested variable: "StripeWebhookSecretArn.Name".

If you find/replace the following in the serverless.yml, deploy is successful.

# original
ENDPOINT_SECRET: "${cf:stripe-eventbridge-deps-${self:provider.stage}.StripeWebhookSecretArn.Name}"

# Replacement
ENDPOINT_SECRET: "${cf:stripe-eventbridge-deps-${self:provider.stage}.StripeWebhookSecretArn}"